### PR TITLE
GHA update: use PredictiveEcology/actions/install-spatial-deps

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,30 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get update -y
-          sudo apt-get install -y libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite0-dev
-
-      - name: Install macOS system dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install pkg-config
-          brew install gdal
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://r-spatial.r-universe.dev/'
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          use-public-rspm: false
-
-      - name: Install sf from r-universe
-        run: |
-          install.packages("sf")
-        shell: Rscript {0}
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.1
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.1
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,6 +40,12 @@ jobs:
 
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          Ncpus: 2
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: false
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |

--- a/.github/workflows/deploy-pkg-website.yaml
+++ b/.github/workflows/deploy-pkg-website.yaml
@@ -24,23 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get update -y
-          sudo apt-get install -y libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite0-dev
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://r-spatial.r-universe.dev/'
-          Ncpus: 2
-          use-public-rspm: false
-
-      - name: Install sf from r-universe
-        run: |
-          install.packages("sf")
-        shell: Rscript {0}
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.1
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/deploy-pkg-website.yaml
+++ b/.github/workflows/deploy-pkg-website.yaml
@@ -26,6 +26,11 @@ jobs:
 
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          Ncpus: 2
+          use-public-rspm: false
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |

--- a/.github/workflows/deploy-pkg-website.yaml
+++ b/.github/workflows/deploy-pkg-website.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.1
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,6 +26,11 @@ jobs:
 
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          Ncpus: 2
+          use-public-rspm: false
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,22 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Install macOS system dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install pkg-config
-          brew install gdal
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://r-spatial.r-universe.dev/'
-          Ncpus: 2
-          use-public-rspm: false
-
-      - name: Install sf from r-universe
-        run: |
-          install.packages("sf")
-        shell: Rscript {0}
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.1
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.1
+      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
GHA update: use PredictiveEcology/actions/install-spatial-deps@v0.2 to install spatial dependencies.

It looks like the steps that were installing spatial dependencies for Linux were outdated, but they have been kept up to date on PredictiveEcology/actions: https://github.com/PredictiveEcology/actions/blob/main/install-spatial-deps/action.yaml.

@cboisvenue the checks are now running again, and are passing :) 