### PR TITLE
CBM disturbances update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ URL:
     https://CBMutils.predictiveecology.org/,
     https://github.com/PredictiveEcology/CBMutils
 Date: 2023-02-28
-Version: 0.0.7.9016
+Version: 0.0.7.9017
 Authors@R: c(
     person("Céline", "Boisvenue", email = "celine.boisvenue@nrcan-rncan.gc.ca", role = c("aut")),
     person("Alex M", "Chubaty", email = "achubaty@for-cast.ca", role = c("aut", "cre"),

--- a/man/spuDist.Rd
+++ b/man/spuDist.Rd
@@ -4,19 +4,29 @@
 \alias{spuDist}
 \title{CBM-CFS3 Spatial Unit Disturbances}
 \usage{
-spuDist(spuIDs, dbPath, localeID = 1)
+spuDist(
+  dbPath,
+  spuIDs = NULL,
+  localeID = 1,
+  disturbance_matrix_association = NULL
+)
 }
 \arguments{
-\item{spuIDs}{Spatial unit ID(s)}
-
 \item{dbPath}{Path to CBM-CFS3 SQLite database file}
 
+\item{spuIDs}{Optional. Subset by spatial unit ID(s)}
+
 \item{localeID}{CBM-CFS3 locale_id}
+
+\item{disturbance_matrix_association}{data.frame. Optional.
+Alternative disturbance_matrix_association table with columns
+"spatial_unit_id", "disturbance_type_id", and "disturbance_matrix_id".}
 }
 \value{
-\code{data.table} with columns
-'spatial_unit_id', 'disturbance_type_id', 'disturbance_matrix_id',
-'name', 'description'
+\code{data.table} with 'disturbance_type_tr' columns
+"spatial_unit_id", "disturbance_type_id", "name", "description"
+and 'disturbance_matrix_association' columns
+"spatial_unit_id" and "disturbance_matrix_id"
 }
 \description{
 Identify the disturbances possible in spatial units.

--- a/tests/testthat/test-CBM-CFS3_DB-ListDisturbances.R
+++ b/tests/testthat/test-CBM-CFS3_DB-ListDisturbances.R
@@ -10,7 +10,7 @@ if (!file.exists(dbPath)){
 
 test_that("spuDist", {
 
-  listDist <- spuDist(27, dbPath = dbPath)
+  listDist <- spuDist(spuIDs = 27, dbPath = dbPath)
 
   expect_true(inherits(listDist, "data.table"))
 


### PR DESCRIPTION
@cboisvenue 2 updates:

1. spuDist function now returns names & descriptions from `disturbance_type_tr` instead of `disturbance_matrix_tr`
2. spuDist now has disturbance_matrix_association argument if the user wants to provide an alternative table matching disturbance IDs to matrix IDs

2 provides a bit of a clunky way to handle working with our cbm_exn `disturbance_matrix_association` table instead of the defaults DB version, however, it's an easy way to get what we need now without majorly restructuring anything. So - a short term solution before we can review `libcbmr` (etc) in more detail.