### PR TITLE
List disturbances functions update: seeDist function revived with tests; EXN argument added

### DIFF
--- a/CBMutils.Rproj
+++ b/CBMutils.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 3303c336-716e-4172-bb6f-497d21910dc8
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/R/CBM-CFS3_DB-ListDisturbances.R
+++ b/R/CBM-CFS3_DB-ListDisturbances.R
@@ -328,17 +328,16 @@ spuDist <- function(EXN = TRUE, spuIDs = NULL,
 #'
 #' Identifies the stand-replacing wildfire disturbance in each spatial unit.
 #'
+#' In all spatial units in Canada, the historical disturbance is set to fire.
 #' Historical disturbances in CBM-CFS3 are used for "filling-up" the soil-related carbon pools.
 #' Boudewyn et al. (2007) translate the m3/ha curves into biomass per ha in each of four pools:
 #' total biomass for stem wood, total biomass for bark, total biomass for branches and total
 #' biomass for foliage.
 #' Biomass in coarse and fine roots, in aboveground- and belowground- very-fast, -fast, -slow,
 #' in medium-soil, and in snags still needs to be estimated.
-#' In all spatial units in Canada, the historical disturbance is set to fire.
 #' A stand-replacing fire disturbance is used in a disturb-grow cycle, where stands are disturbed
 #' and regrown with turnover, overmature, decay, functioning until the dead organic matter pools
-#' biomass values stabilize (+/- 10%).
-#' ## TODO: (I think but that is in the Rcpp-RCMBGrowthIncrements.cpp so can't check).
+#' biomass values stabilize (+/- 10%) (TODO: check this).
 #'
 #' @param spuIDs Spatial unit ID(s)
 #' @param localeID CBM-CFS3 locale_id
@@ -412,10 +411,15 @@ seeDist <- function(EXN = TRUE, matrixIDs = NULL,
 
     cbmDBM <- {
       tableNames <- c("disturbance_matrix_value", "pool")
-      lapply(setNames(tableNames, tableNames), function(nm){
+      names(tableNames) <- tableNames
+      lapply(tableNames, function(nm){
         as.data.table(dbReadTable(cbmDBcon, nm))
       })
     }
+
+    # CRAN requirement: predefine variables
+    source_pool_id <- source_pool <- sink_pool_id <- sink_pool <- proportion <- code <- NULL
+
     cbmDBM[["pool_source"]] <- copy(cbmDBM[["pool"]])[, source_pool := code]
     cbmDBM[["pool_sink"]]   <- copy(cbmDBM[["pool"]])[, sink_pool   := code]
     disturbance_matrix_value <- cbmDBM[["disturbance_matrix_value"]] |>

--- a/man/histDist.Rd
+++ b/man/histDist.Rd
@@ -21,16 +21,14 @@ If FALSE, the function will look for exact name matches.}
 Identifies the stand-replacing wildfire disturbance in each spatial unit.
 }
 \details{
+In all spatial units in Canada, the historical disturbance is set to fire.
 Historical disturbances in CBM-CFS3 are used for "filling-up" the soil-related carbon pools.
 Boudewyn et al. (2007) translate the m3/ha curves into biomass per ha in each of four pools:
 total biomass for stem wood, total biomass for bark, total biomass for branches and total
 biomass for foliage.
 Biomass in coarse and fine roots, in aboveground- and belowground- very-fast, -fast, -slow,
 in medium-soil, and in snags still needs to be estimated.
-In all spatial units in Canada, the historical disturbance is set to fire.
 A stand-replacing fire disturbance is used in a disturb-grow cycle, where stands are disturbed
 and regrown with turnover, overmature, decay, functioning until the dead organic matter pools
-biomass values stabilize (+/- 10\%).
-\subsection{TODO: (I think but that is in the Rcpp-RCMBGrowthIncrements.cpp so can't check).}{
-}
+biomass values stabilize (+/- 10\%) (TODO: check this).
 }

--- a/man/histDist.Rd
+++ b/man/histDist.Rd
@@ -4,23 +4,18 @@
 \alias{histDist}
 \title{CBM-CFS3 Historical Disturbances}
 \usage{
-histDist(spuIDs, dbPath = NULL, localeID = 1, listDist = NULL, ask = FALSE)
+histDist(spuIDs, localeID = 1, ask = FALSE, ...)
 }
 \arguments{
 \item{spuIDs}{Spatial unit ID(s)}
 
-\item{dbPath}{Path to CBM-CFS3 SQLite database file}
-
 \item{localeID}{CBM-CFS3 locale_id}
-
-\item{listDist}{data.table. Optional. Result of a call to \code{\link{spuDist}}.
-A list of possible disturbances in the spatial unit(s) with columns
-'spatial_unit_id', 'disturbance_type_id', 'disturbance_matrix_id', 'name', 'description'.
-If provided, the \code{dbPath} and \code{localeID} arguments are not required.}
 
 \item{ask}{logical.
 If TRUE, prompt the user to choose the correct disturbance matches.
 If FALSE, the function will look for exact name matches.}
+
+\item{...}{arguments to \code{\link{spuDistMatch}}}
 }
 \description{
 Identifies the stand-replacing wildfire disturbance in each spatial unit.
@@ -37,7 +32,5 @@ A stand-replacing fire disturbance is used in a disturb-grow cycle, where stands
 and regrown with turnover, overmature, decay, functioning until the dead organic matter pools
 biomass values stabilize (+/- 10\%).
 \subsection{TODO: (I think but that is in the Rcpp-RCMBGrowthIncrements.cpp so can't check).}{
-
-By default the most recent is selected, but the user can change that.
 }
 }

--- a/man/seeDist.Rd
+++ b/man/seeDist.Rd
@@ -4,17 +4,27 @@
 \alias{seeDist}
 \title{See disturbances}
 \usage{
-seeDist(distId, dbPath)
+seeDist(
+  EXN = TRUE,
+  matrixIDs = NULL,
+  dbPath = NULL,
+  disturbance_matrix_value = NULL
+)
 }
 \arguments{
-\item{distId}{Description needed}
+\item{EXN}{logical. Use CBM-EXN CBM-CFS3 equivalent model data.}
 
-\item{dbPath}{Path to sqlite database file.}
+\item{matrixIDs}{character. Optional. Subset disturbances by disturbance_matrix_id}
+
+\item{dbPath}{Path to CBM-CFS3 SQLite database file.
+Required if EXN = FALSE}
+
+\item{disturbance_matrix_value}{disturbance_matrix_value table from CBM-EXN
+Required if EXN = TRUE}
 }
 \value{
-A list of \code{data.frame}s, one per disturbance matrix id.
+List of \code{data.frame} named by disturbance_matrix_id
 }
 \description{
-Get the descriptive name of the disturbance, the source pools, the sink pools, and
-the proportions transferred.
+Retrieve disturbance source pools, sink pools, and the proportions transferred.
 }

--- a/man/spuDist.Rd
+++ b/man/spuDist.Rd
@@ -5,22 +5,27 @@
 \title{CBM-CFS3 Spatial Unit Disturbances}
 \usage{
 spuDist(
-  dbPath,
+  EXN = TRUE,
   spuIDs = NULL,
-  localeID = 1,
-  disturbance_matrix_association = NULL
+  dbPath = NULL,
+  disturbance_matrix_association = NULL,
+  localeID = 1
 )
 }
 \arguments{
-\item{dbPath}{Path to CBM-CFS3 SQLite database file}
+\item{EXN}{logical. Use CBM-EXN CBM-CFS3 equivalent model data.}
 
 \item{spuIDs}{Optional. Subset by spatial unit ID(s)}
 
-\item{localeID}{CBM-CFS3 locale_id}
+\item{dbPath}{Path to CBM-CFS3 SQLite database file.
+Required if EXN = TRUE or EXN = FALSE.}
 
 \item{disturbance_matrix_association}{data.frame. Optional.
 Alternative disturbance_matrix_association table with columns
-"spatial_unit_id", "disturbance_type_id", and "disturbance_matrix_id".}
+"spatial_unit_id", "disturbance_type_id", and "disturbance_matrix_id".
+Required if EXN = TRUE.}
+
+\item{localeID}{CBM-CFS3 locale_id}
 }
 \value{
 \code{data.table} with 'disturbance_type_tr' columns

--- a/man/spuDistMatch.Rd
+++ b/man/spuDistMatch.Rd
@@ -8,9 +8,8 @@ spuDistMatch(
   distTable,
   ask = interactive(),
   nearMatches = TRUE,
-  dbPath = NULL,
-  localeID = 1,
-  listDist = NULL
+  listDist = NULL,
+  ...
 )
 }
 \arguments{
@@ -24,14 +23,12 @@ If FALSE, the function will look for exact name matches.}
 
 \item{nearMatches}{logical. Allow for near matches; e.g. "clearcut" can match "clear-cut".}
 
-\item{dbPath}{Path to CBM-CFS3 SQLite database file}
-
-\item{localeID}{CBM-CFS3 locale_id}
-
 \item{listDist}{data.table. Optional. Result of a call to \code{\link{spuDist}}.
 A list of possible disturbances in the spatial unit(s) with columns
-'spatial_unit_id', 'disturbance_type_id', 'disturbance_matrix_id', 'name', 'description'.
-If provided, the \code{dbPath} and \code{localeID} arguments are not required.}
+'spatial_unit_id', 'disturbance_type_id', 'disturbance_matrix_id', 'name', 'description'.}
+
+\item{...}{arguments to \code{\link{spuDist}}
+for listing the possible disturbances in the spatial units.}
 }
 \value{
 \code{data.table} with columns 'spatial_unit_id'

--- a/tests/testthat/devel-runTests.R
+++ b/tests/testthat/devel-runTests.R
@@ -1,0 +1,7 @@
+
+# Run all tests
+testthat::test_local()
+
+# Run subsets of tests
+testthat::test_local(filter = "DB-ListDisturbances")
+

--- a/tests/testthat/test-CBM-CFS3_DB-ListDisturbances.R
+++ b/tests/testthat/test-CBM-CFS3_DB-ListDisturbances.R
@@ -1,19 +1,43 @@
 
+## SET UP ----
+
 if (!testthat::is_testing()) source(testthat::test_path("setup.R"))
 
-# Download CBM-CFS3 database
-cbmDBs <- list(
-  defaults = "https://raw.githubusercontent.com/cat-cfs/libcbm_py/main/libcbm/resources/cbm_defaults_db/cbm_defaults_v1.2.8340.362.db",
-  exn_dma  = "https://raw.githubusercontent.com/cat-cfs/libcbm_py/refs/heads/main/libcbm/resources/cbm_exn/disturbance_matrix_association.csv"
-) |> lapply(function(url){
+# Download CBM-CFS3 databases
+dbPath <- {
+  url = "https://raw.githubusercontent.com/cat-cfs/libcbm_py/main/libcbm/resources/cbm_defaults_db/cbm_defaults_v1.2.8340.362.db"
   destfile <- file.path(testDirs$temp$inputs, basename(url))
   download.file(url = url, destfile = destfile, mode = "wb", quiet = TRUE)
   file.path(testDirs$temp$inputs, basename(url))
-})
+}
+exnDB <- {
+  csvNames <- c("disturbance_matrix_association", "disturbance_matrix_value")
+  lapply(setNames(csvNames, csvNames), function(csvName){
+    url = file.path(
+      "https://raw.githubusercontent.com/cat-cfs/libcbm_py/main/libcbm/resources/cbm_exn",
+      paste0(csvName, ".csv"))
+    destfile <- file.path(testDirs$temp$inputs, basename(url))
+    download.file(url = url, destfile = destfile, quiet = TRUE)
+    read.csv(destfile, stringsAsFactors = FALSE, row.names = NULL)
+  })
+}
+
+
+## TEST ----
 
 test_that("spuDist", {
 
-  listDist <- spuDist(spuIDs = 27, dbPath = cbmDBs[["defaults"]])
+  # cbm_exn = FALSE
+
+  ## Expect error: dbPath missing
+  expect_error(
+    spuDist(spuIDs = 27, EXN = FALSE, dbPath = NULL,
+            disturbance_matrix_association = exnDB[["disturbance_matrix_association"]]),
+    "dbPath"
+  )
+
+  ## Expect success
+  listDist <- spuDist(spuIDs = 27, EXN = FALSE, dbPath = dbPath)
 
   expect_true(inherits(listDist, "data.table"))
 
@@ -24,8 +48,27 @@ test_that("spuDist", {
   expect_true(all(listDist$spatial_unit_id == 27))
   expect_true(nrow(listDist) == 133)
 
-  # Test with user provided disturbance_matrix_association
-  listDist <- spuDist(spuIDs = 27, dbPath = cbmDBs[["defaults"]], disturbance_matrix_association = read.csv(cbmDBs[["exn_dma"]]))
+
+  # EXN = TRUE
+
+  ## Expect error: dbPath missing
+  expect_error(
+    spuDist(spuIDs = 27, EXN = TRUE, dbPath = NULL,
+            disturbance_matrix_association = exnDB[["disturbance_matrix_association"]]),
+    'dbPath'
+  )
+
+  ## Expect error: disturbance_matrix_association missing
+  expect_error(
+    spuDist(spuIDs = 27, EXN = TRUE, dbPath = dbPath,
+            disturbance_matrix_association = NULL),
+    'disturbance_matrix_association'
+  )
+
+  ## Expect success
+  listDist <- spuDist(
+    spuIDs = 27, EXN = TRUE, dbPath = dbPath,
+    disturbance_matrix_association = exnDB[["disturbance_matrix_association"]])
   expect_true(all(listDist$spatial_unit_id == 27))
   expect_true(nrow(listDist) == 266)
 
@@ -41,11 +84,19 @@ test_that("spuDistMatch", {
     data.frame(rasterID = 4, wholeStand = 1, distName = "Deforestation")
   )
 
-  # Try with a single spuID
-  spuIDs <- 28
-  distTable <- cbind(spatial_unit_id = spuIDs, distTypes)
+  # EXN = FALSE
 
-  listDist <- spuDistMatch(distTable, dbPath = cbmDBs[["defaults"]], ask = FALSE)
+  ## Expect error: dbPath missing
+  expect_error(
+    spuDistMatch(distTable = cbind(spatial_unit_id = 28, distTypes),
+                 EXN = FALSE, ask = FALSE, dbPath = NULL),
+    "dbPath"
+  )
+
+  ## Try with a single spuID
+  listDist <- spuDistMatch(
+    distTable = cbind(spatial_unit_id = 28, distTypes),
+    EXN = FALSE, ask = FALSE, dbPath = dbPath)
 
   expect_true(inherits(listDist, "data.table"))
 
@@ -55,13 +106,11 @@ test_that("spuDistMatch", {
 
   expect_equal(listDist$disturbance_matrix_id, c(371, 160, 91, 26))
 
-  # Try with 2 spuIDs
-  spuIDs <- c(27, 28)
-  distTable <- do.call(rbind, lapply(spuIDs, function(spuID){
-    cbind(spatial_unit_id = spuID, distTypes)
-  }))
-
-  listDist <- spuDistMatch(distTable, dbPath = cbmDBs[["defaults"]], ask = FALSE)
+  ## Try with 2 spuIDs
+  listDist <- spuDistMatch(
+    distTable = rbind(cbind(spatial_unit_id = 27, distTypes),
+                      cbind(spatial_unit_id = 28, distTypes)),
+    EXN = FALSE, ask = FALSE, dbPath = dbPath)
 
   expect_true(inherits(listDist, "data.table"))
   expect_true(all(c(
@@ -73,10 +122,49 @@ test_that("spuDistMatch", {
     371, 160, 91, 26
   ))
 
-  # Test 2 spuIDs and user provided disturbance_matrix_association
-  listDist <- spuDist(dbPath = cbmDBs[["defaults"]], disturbance_matrix_association = read.csv(cbmDBs[["exn_dma"]]))
+  ## Expect error: name does not have an exact match and ask = FALSE
+  expect_error(
+    spuDistMatch(
+      distTable = data.frame(spatial_unit_id = 27, name = "clearcut"),
+      EXN = FALSE, ask = FALSE, dbPath = dbPath)
+  )
 
-  listDist <- spuDistMatch(distTable, listDist = listDist, ask = FALSE)
+  ## Test with listDist provided
+  listDist2 <- spuDistMatch(
+    distTable = rbind(cbind(spatial_unit_id = 27, distTypes),
+                      cbind(spatial_unit_id = 28, distTypes)),
+    listDist = spuDist(EXN = FALSE, dbPath = dbPath),
+    ask = FALSE)
+
+  expect_identical(listDist, listDist2)
+
+
+  # EXN = TRUE
+
+  ## Expect error: dbPath missing
+  expect_error(
+    spuDistMatch(
+      distTable = cbind(spatial_unit_id = 28, distTypes),
+      EXN = TRUE, ask = FALSE, dbPath = NULL,
+      disturbance_matrix_association = exnDB[["disturbance_matrix_association"]]),
+    "dbPath"
+  )
+
+  ## Expect error: disturbance_matrix_association missing
+  expect_error(
+    spuDistMatch(
+      distTable = cbind(spatial_unit_id = 28, distTypes),
+      EXN = TRUE, ask = FALSE, dbPath = dbPath,
+      disturbance_matrix_association = NULL),
+    "disturbance_matrix_association"
+  )
+
+  ## Test 2 spuIDs
+  listDist <- spuDistMatch(
+    distTable = rbind(cbind(spatial_unit_id = 27, distTypes),
+                      cbind(spatial_unit_id = 28, distTypes)),
+    EXN = TRUE, ask = FALSE, dbPath = dbPath,
+    disturbance_matrix_association = exnDB[["disturbance_matrix_association"]])
 
   expect_true(inherits(listDist, "data.table"))
   expect_true(all(c(
@@ -88,15 +176,26 @@ test_that("spuDistMatch", {
     371, 851, 160, 640, 91, 571, 26, 506
   ))
 
-  # Expect error: name does not have an exact match and ask = FALSE
+  ## Expect error: name does not have an exact match and ask = FALSE
   expect_error(
-    spuDistMatch(data.frame(spatial_unit_id = 27, name = "clearcut"), dbPath = cbmDBs[["defaults"]], ask = FALSE)
+    spuDistMatch(
+      distTable = data.frame(spatial_unit_id = 27, name = "clearcut"),
+      EXN = TRUE, ask = FALSE, dbPath = dbPath,
+      disturbance_matrix_association = exnDB[["disturbance_matrix_association"]])
   )
 })
 
 test_that("histDist", {
 
-  listDist <- histDist(27, dbPath = cbmDBs[["defaults"]])
+  # EXN = FALSE
+
+  ## Expect error: dbPath missing
+  expect_error(
+    histDist(spuIDs = 27, EXN = FALSE, dbPath = NULL),
+    "dbPath"
+  )
+
+  listDist <- histDist(spuIDs = 27, EXN = FALSE, dbPath = dbPath)
 
   expect_true(inherits(listDist, "data.table"))
 
@@ -111,5 +210,103 @@ test_that("histDist", {
   # Result should be for name "Wildfire"
   expect_true(listDist$disturbance_matrix_id == 378)
 
+
+  # EXN = TRUE
+
+  ## Expect error: dbPath missing
+  expect_error(
+    histDist(spuIDs = 27, EXN = TRUE, dbPath = NULL),
+    "dbPath"
+  )
+
+  ## Expect error: disturbance_matrix_association missing
+  expect_error(
+    histDist(spuIDs = 27, EXN = TRUE, dbPath = dbPath),
+    "disturbance_matrix_association"
+  )
+
+  listDist <- histDist(
+    spuIDs = 27, EXN = TRUE, dbPath = dbPath,
+    disturbance_matrix_association = exnDB[["disturbance_matrix_association"]])
+
+  expect_true(inherits(listDist, "data.table"))
+
+  expect_true(all(c(
+    "spatial_unit_id", "disturbance_type_id", "disturbance_matrix_id", "name", "description"
+  ) %in% names(listDist)))
+
+  expect_true(all(listDist$spatial_unit_id == 27))
+
+  expect_true(nrow(listDist) == 2)
+
+  # Result should be for name "Wildfire"
+  expect_true(all(listDist$disturbance_matrix_id == c(378, 858)))
+
 })
+
+test_that("seeDist", {
+
+  # EXN = FALSE
+
+  ## Expect error: dbPath missing
+  expect_error(
+    seeDist(EXN = FALSE, dbPath = NULL),
+    "dbPath"
+  )
+
+  distVals <- seeDist(EXN = FALSE, dbPath = dbPath)
+
+  expect_true(inherits(distVals, "list"))
+  expect_true(inherits(distVals[[1]], "data.table"))
+
+  expect_true(all(c(
+    "disturbance_matrix_id", "source_pool", "sink_pool", "proportion"
+  ) %in% names(distVals[[1]])))
+
+  ## Test providing a matrix ID
+  distVals <- seeDist(matrixIDs = 2, EXN = FALSE, dbPath = dbPath)
+
+  expect_true(inherits(distVals, "list"))
+  expect_true(inherits(distVals[[1]], "data.table"))
+
+  expect_true(all(c(
+    "disturbance_matrix_id", "source_pool", "sink_pool", "proportion"
+  ) %in% names(distVals[[1]])))
+
+  expect_identical(names(distVals), "2")
+  expect_true(all(distVals[["2"]]$disturbance_matrix_id == 2))
+
+
+  # EXN = TRUE
+
+  ## Expect error: disturbance_matrix_value missing
+  expect_error(
+    seeDist(EXN = TRUE, dbPath = NULL),
+    "disturbance_matrix_value"
+  )
+
+  distVals <- seeDist(EXN = TRUE, disturbance_matrix_value = exnDB[["disturbance_matrix_value"]])
+
+  expect_true(inherits(distVals, "list"))
+  expect_true(inherits(distVals[[1]], "data.table"))
+
+  expect_true(all(c(
+    "disturbance_matrix_id", "source_pool", "sink_pool", "proportion"
+  ) %in% names(distVals[[1]])))
+
+  ## Test providing a matrix ID
+  distVals <- seeDist(matrixIDs = 2, EXN = TRUE, disturbance_matrix_value = exnDB[["disturbance_matrix_value"]])
+
+  expect_true(inherits(distVals, "list"))
+  expect_true(inherits(distVals[[1]], "data.table"))
+
+  expect_true(all(c(
+    "disturbance_matrix_id", "source_pool", "sink_pool", "proportion"
+  ) %in% names(distVals[[1]])))
+
+  expect_identical(names(distVals), "2")
+  expect_true(all(distVals[["2"]]$disturbance_matrix_id == 2))
+
+})
+
 


### PR DESCRIPTION
Two updates:
1. `spuDist`, `spuDistMatch`, and `histDist` functions now have the EXN argument with default TRUE.

The EXN argument has been added with default TRUE as an extra protection to listing disturbances. If EXN = TRUE, the function now checks that the user has provided the CBM-EXN csv table(s) required to return the correct results. For these functions, that means it is now checking that the `disturbance_matrix_association` input table was provided. 

3. `seeDist` function revived with tests

`seeDist` function revived with tests added. It also has the EXN argument with default TRUE. If EXN = TRUE, the `disturbance_matrix_value` CBM-EXN CSV table is required. if EXN = FALSE, `dbPath` is required.

An example of the results:

```
> distVals <- seeDist(matrixIDs = 2, disturbance_matrix_value = {
+   url = "https://raw.githubusercontent.com/cat-cfs/libcbm_py/main/libcbm/resources/cbm_exn/disturbance_matrix_value.csv"
+   destfile <- file.path(tempdir(), basename(url))
+   download.file(url = url, destfile = destfile, quiet = TRUE)
+   read.csv(destfile, stringsAsFactors = FALSE, row.names = NULL)
+ })
> head(distVals[["2"]], 5)
   disturbance_matrix_id source_pool sink_pool proportion
                   <int>      <char>    <char>      <num>
1:                     2       Merch  StemSnag    0.68624
2:                     2       Merch       CO2    0.28102
3:                     2       Merch       CH4    0.00316
4:                     2       Merch        CO    0.02842
5:                     2     Foliage       CO2    0.85570
```