### PR TITLE
Simple fix to biomProp in cases where the same canfi_species code in a single ecozone/jurisdiction has 2 entries

### DIFF
--- a/R/growthCurves.R
+++ b/R/growthCurves.R
@@ -187,26 +187,26 @@ biomProp <- function(table6, table7, x, type = "volume") {
 
   lvol <- log(x + 5)
 
-  ## denominator is the same for all 4 equations
-  denom <- (1 + exp(table6[, a1] + table6[, a2] * x + table6[, a3] * lvol) +
-              exp(table6[, b1] + table6[, b2] * x + table6[, b3] * lvol) +
-              exp(table6[, c1] + table6[, c2] * x + table6[, c3] * lvol))
+ ## denominator is the same for all 4 equations
+  denom <- (1 + exp(table6[1, a1] + table6[1, a2] * x + table6[1, a3] * lvol) +
+              exp(table6[1, b1] + table6[1, b2] * x + table6[1, b3] * lvol) +
+              exp(table6[1, c1] + table6[1, c2] * x + table6[1, c3] * lvol))
   ## for each proportion, enforce caps per table 7
   pstem <- 1 / denom
-  pstem[which(x < caps[1])] <- table7$p_sw_low
-  pstem[which(x > caps[2])] <- table7$p_sw_high
+  pstem[which(x < caps[1])] <- table7[1, p_sw_low]
+  pstem[which(x > caps[2])] <- table7[1, p_sw_high]
 
-  pbark <- exp(table6[, a1] + table6[, a2] * x + table6[, a3] * lvol) / denom
-  pbark[which(x < caps[1])] <- table7$p_sb_low
-  pbark[which(x > caps[2])] <- table7$p_sb_high
+  pbark <- exp(table6[1, a1] + table6[1, a2] * x + table6[1, a3] * lvol) / denom
+  pbark[which(x < caps[1])] <- table7[1, p_sb_low]
+  pbark[which(x > caps[2])] <- table7[1, p_sb_high]
 
-  pbranches <- exp(table6[, b1] + table6[, b2] * x + table6[, b3] * lvol) / denom
-  pbranches[which(x < caps[1])] <- table7$p_br_low
-  pbranches[which(x > caps[2])] <- table7$p_br_high
+  pbranches <- exp(table6[1, b1] + table6[1, b2] * x + table6[1, b3] * lvol) / denom
+  pbranches[which(x < caps[1])] <- table7[1, p_br_low]
+  pbranches[which(x > caps[2])] <- table7[1, p_br_high]
 
-  pfol <- exp(table6[, c1] + table6[, c2] * x + table6[, c3] * lvol) / denom
-  pfol[which(x < caps[1])] <- table7$p_fl_low
-  pfol[which(x > caps[2])] <- table7$p_fl_high
+  pfol <- exp(table6[, c1] + table6[1, c2] * x + table6[1, c3] * lvol) / denom
+  pfol[which(x < caps[1])] <- table7[1, p_fl_low]
+  pfol[which(x > caps[2])] <- table7[1, p_fl_high]
 
   propVect <- cbind(pstem = pstem, pbark = pbark, pbranches = pbranches, pfol = pfol)
 

--- a/R/growthCurves.R
+++ b/R/growthCurves.R
@@ -154,12 +154,12 @@ biomProp <- function(table6, table7, x, type = "volume") {
     if(any(!(c("vol_min", "vol_max") %in% colnames(table7)))) {
       stop("The parameter tables do not have the correct columns for ", type, " inputs.")
     }
-    caps <- as.numeric(table7[,c("vol_min", "vol_max")])
+    caps <- as.numeric(table7[1 ,c("vol_min", "vol_max")])
   } else if (type == "biomass") {
     if(any(!(c("biom_min", "biom_max") %in% colnames(table7)))) {
       stop("The parameter tables do not have the correct columns for ", type, " inputs.")
     }
-    caps <- as.numeric(table7[,c("biom_min", "biom_max")])
+    caps <- as.numeric(table7[1 ,c("biom_min", "biom_max")])
   } else {
     stop("The argument type in biomProp() needs to be `volume` or `biomass`")
   }


### PR DESCRIPTION
In some instances, certain `canfi_species` codes have 2 (or more) identical entries due to differences in `variety` in the Boudewyn tables (specifically table 7 in this case). This causes the function (and therefore certain CBM runs) to fail. 
In CBM, the error is caused by the canfi_species code 1303 (species of birch) that has 2 entries with identical values which leads to this error when running SK. 

This fix forces the function to only and always use the first entry. Which entry we choose does not matter since values are identical between entries with the same `canfi_species` codes that also share the same `juris_id` and `ecozone` in table 7. 

Hopefully this makes sense!

I've also added Dominique as a reviewer since this is an edit to some of his changes. 