### PR TITLE
small fix to spatialPlot function so NAs don't become 0s

### DIFF
--- a/R/CBM-plots.R
+++ b/R/CBM-plots.R
@@ -39,7 +39,7 @@ spatialPlot <- function(cbmPools, years, masterRaster, spatialDT) {
   setkey(totalCarbon, pixelGroup)
   temp <- merge(t, totalCarbon, allow.cartesian=TRUE)
   setkey(temp, pixelIndex)
-  plotM <- terra::rast(masterRaster, vals = 0)
+  plotM <- terra::rast(masterRaster)
   terra::values(plotM)[temp$pixelIndex] <- temp$totalCarbon
   pixSize <- prod(terra::res(masterRaster))/10000
   temp[, `:=`(pixTC, totalCarbon * pixSize)]


### PR DESCRIPTION
Small aesthetic change to the plotting. This allows NAs to be transparent (like the NPP figure) rather than bright red. This makes it much easier to parse the figure when looking at it and makes the legend colour scale more meaningful. 