### PR TITLE
sppMatch update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Implementation of several components of the Carbon Budget Model of 
     Canadian Forest Service (v3).
 URL:
     https://github.com/PredictiveEcology/CBMutils
-Version: 2.0.2.0000
+Version: 2.0.2.0001
 Authors@R: c(
     person("Céline",    "Boisvenue", email = "celine.boisvenue@nrcan-rncan.gc.ca", role = c("aut")),
     person("Alex M",    "Chubaty",   email = "achubaty@for-cast.ca",               role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7146-8135")),

--- a/man/sppMatch.Rd
+++ b/man/sppMatch.Rd
@@ -6,21 +6,26 @@
 \usage{
 sppMatch(
   species,
-  matchCol = NULL,
-  sppEquivalencies = NULL,
-  checkNA = c("CBM_speciesID", "Broadleaf")
+  match = NULL,
+  return = NULL,
+  checkNA = !is.null(return),
+  sppEquivalencies = NULL
 )
 }
 \arguments{
 \item{species}{Species identifiers.}
 
-\item{matchCol}{character. \code{sppEquivalencies} columns to match \code{species} with.
+\item{match}{character. \code{sppEquivalencies} columns to match \code{species} with.
 Defaults to \code{LandR::sppEquivalencies_CA} columns with Latin and generic English species names.}
+
+\item{return}{character. \code{sppEquivalencies} columns to return.
+All columns will be returned by default.}
+
+\item{checkNA}{logical. Check for NA values in the returned columns.
+Defaults to TRUE if the \code{return} argument is used; otherwise FALSE.}
 
 \item{sppEquivalencies}{data.table. Table of species identifiers and metadata.
 Defaults to \code{LandR::sppEquivalencies_CA}.}
-
-\item{checkNA}{character. \code{sppEquivalencies} columns to check for NA values in.}
 }
 \value{
 data.table. Subset of \code{sppEquivalencies} with 1 row per species.

--- a/tests/testthat/test-CBM-DB_species.R
+++ b/tests/testthat/test-CBM-DB_species.R
@@ -70,7 +70,8 @@ test_that("sppMatch", {
   expect_error(
     sppMatch(
       species = speciesNames,
-      checkNA = c("CBM_speciesID", "Broadleaf"),
+      return  = c("CBM_speciesID", "Broadleaf"),
+      check   = TRUE,
       sppEquivalencies = cbind(
         sppEquivalencies[sppEquivalencies$CBM_speciesID %in% c(35, 88), .SD, .SDcols = !"CBM_speciesID"],
         CBM_speciesID = c(NA, 1))
@@ -81,7 +82,8 @@ test_that("sppMatch", {
   expect_error(
     sppMatch(
       species = speciesNames,
-      checkNA = c("CanfiCode", "column_not_found"),
+      return  = c("CBM_speciesID", "column_not_found"),
+      check   = TRUE,
       sppEquivalencies = sppEquivalencies
     )
   )
@@ -93,30 +95,30 @@ test_that("sppMatch to a chosen column", {
 
   # Match with a specific column
   sppTable <- sppMatch(
-    species  = c(2201, 301),
-    matchCol = "CanfiCode",
+    species = c(2201, 301),
+    match   = "CanfiCode",
     sppEquivalencies = sppEquivalencies
   )
   expect_equal(sppTable$CBM_speciesID, c(122, 28))
 
   sppTable <- sppMatch(
-    species  = c("ulmu_ame", "abie_ama"),
-    matchCol = "LandR",
+    species = c("ulmu_ame", "abie_ama"),
+    match   = "LandR",
     sppEquivalencies = sppEquivalencies
   )
   expect_equal(sppTable$CBM_speciesID, c(122, 28))
 
   sppTable <- sppMatch(
-    species  = c("ulmus americana", "abies amabilis"),
-    matchCol = "Latin_full",
+    species = c("ulmus americana", "abies amabilis"),
+    match   = "Latin_full",
     sppEquivalencies = sppEquivalencies
   )
   expect_equal(sppTable$CBM_speciesID, c(122, 28))
 
   # 0 matches
   sppTable <- sppMatch(
-    species  = c(),
-    matchCol = "CanfiCode",
+    species = c(),
+    match   = "CanfiCode",
     sppEquivalencies = sppEquivalencies
   )
   expect_equal(nrow(sppTable), 0)
@@ -124,8 +126,8 @@ test_that("sppMatch to a chosen column", {
   # Expect error: NAs in input
   expect_error(
     sppMatch(
-      species  = c(NA, 2201),
-      matchCol = "CanfiCode",
+      species = c(NA, 2201),
+      match   = "CanfiCode",
       sppEquivalencies = sppEquivalencies
     )
   )
@@ -133,8 +135,8 @@ test_that("sppMatch to a chosen column", {
   # Expect error: match to a column that doesn't exist
   expect_error(
     sppMatch(
-      species  = c(301, 2201),
-      matchCol = "CanfiCode",
+      species = c(301, 2201),
+      match   = "CanfiCode",
       sppEquivalencies = sppEquivalencies[, .SD, .SDcols = c(
         "Latin_full", "CBM_speciesID", "Broadleaf")])
   )
@@ -142,8 +144,8 @@ test_that("sppMatch to a chosen column", {
   # Expect error: match not found
   expect_error(
     sppMatch(
-      species  = c(301, 2201),
-      matchCol = "CanfiCode",
+      species = c(301, 2201),
+      match   = "CanfiCode",
       sppEquivalencies = sppEquivalencies[!sppEquivalencies$CanfiCode %in% 301,]
     ),
     "301")
@@ -151,8 +153,8 @@ test_that("sppMatch to a chosen column", {
   # Expect error: multiple matches
   expect_error(
     sppMatch(
-      species  = c(301, 2201),
-      matchCol = "CanfiCode",
+      species = c(301, 2201),
+      match   = "CanfiCode",
       sppEquivalencies = rbind(
         sppEquivalencies,
         sppEquivalencies[sppEquivalencies$CanfiCode %in% 301,]
@@ -162,9 +164,10 @@ test_that("sppMatch to a chosen column", {
   # Expect error: NAs found
   expect_error(
     sppMatch(
-      species  = c(301, 2201),
-      matchCol = "CanfiCode",
-      checkNA  = c("CBM_speciesID", "Broadleaf"),
+      species = c(301, 2201),
+      match   = "CanfiCode",
+      return  = c("CBM_speciesID", "Broadleaf"),
+      check   = TRUE,
       sppEquivalencies = cbind(
         sppEquivalencies[sppEquivalencies$CanfiCode %in% c(301, 2201), .SD, .SDcols = !"CBM_speciesID"],
         CBM_speciesID = c(NA, 1))
@@ -174,9 +177,10 @@ test_that("sppMatch to a chosen column", {
   # Expect error: check NAs for a column that doesn't exist
   expect_error(
     sppMatch(
-      species  = c(301, 2201),
-      matchCol = "CanfiCode",
-      checkNA  = c("CanfiCode", "column_not_found"),
+      species = c(301, 2201),
+      match   = "CanfiCode",
+      return  = c("CBM_speciesID", "column_not_found"),
+      check   = TRUE,
       sppEquivalencies = sppEquivalencies
     )
   )


### PR DESCRIPTION
- 'return' argument added to choose which columns to return (allowing for duplicate matches in come cases); 
- checkNA now is a logical argument of whether or not to check for NAs.
- 'matchCol' argument renamed 'match'

attn @DominiqueCaron @camillegiuliano

A small update to the `sppMatch` to help make the function work for SK. I was getting the error that there were multiple matches for "Balsam poplar" (both [here](https://github.com/PredictiveEcology/LandR/blob/67a012c8e26cd25ae332a34a7a174296acbb956e/data-raw/sppEquivalencies_CA.csv#L127) and [here](https://github.com/PredictiveEcology/LandR/blob/67a012c8e26cd25ae332a34a7a174296acbb956e/data-raw/sppEquivalencies_CA.csv#L128)) but both rows have the same values in `CBM_speciesID` and `Broadleaf` so for the module's purposes, this is OK.

I added the `return` argument so that the user can choose which columns they need returned, and an error will only be thrown if there are multiple matches with differing values in these columns. Otherwise, it will still be able to return 1 row per input species.