### PR TITLE
Fix sw_hw in calcRootC

### DIFF
--- a/R/CBM-tools_calcRootC.R
+++ b/R/CBM-tools_calcRootC.R
@@ -8,7 +8,7 @@ utils::globalVariables(c(
 #' `calcRootC` calculates the mass of carbon in roots pools from above ground pools
 #'
 #' @param aboveGroundC data.table with mass of carbon (tonnes/ha) in the Merch, Foliage and Other pools
-#' @param sw_hw a boolean vector indicating if the cohort is softwood (1) or hardwood (0)
+#' @param sw_hw a boolean vector indicating if the cohort is softwood (0) or hardwood (1)
 #' @param a_sw DESCRIPTION NEEDED
 #' @param b_sw DESCRIPTION NEEDED
 #' @param a_hw DESCRIPTION NEEDED
@@ -48,7 +48,7 @@ calcRootC <- function(aboveGroundC, sw_hw,
     stop("sw_hw needs to be a boolean vector")
   }
 
-  rootTotBiom <- ifelse(sw_hw == 1,
+  rootTotBiom <- ifelse(sw_hw == 0,
                         a_sw * totAGB^b_sw,
                         a_hw * totAGB^b_hw)
 

--- a/R/CBM-tools_calcRootC.R
+++ b/R/CBM-tools_calcRootC.R
@@ -53,7 +53,7 @@ calcRootC <- function(aboveGroundC, sw_hw,
                         a_hw * totAGB^b_hw)
 
   # Calculate the proportion of fine roots
-  fineRootProp <- a_frp + b_frp * exp(-0.060 * rootTotBiom)
+  fineRootProp <- a_frp + b_frp * exp(-0.060212 * rootTotBiom)
 
 
   # Calculate the proportion of fine roots

--- a/tests/testthat/test-CBM-tools_calcRootC.R
+++ b/tests/testthat/test-CBM-tools_calcRootC.R
@@ -5,28 +5,28 @@ test_that("calcRootC", {
   ABC <- data.table(Merch = c(0,1),
                     Foliage = c(3,1),
                     Other = c(1,1))
-  sw_hw = c(1,0)
+  sw_hw = c(0,1)
   rootC <- calcRootC(aboveGroundC = ABC, sw_hw = sw_hw)
 
   # Works correctly
   expect_identical(
-    round(rootC,3), 
+    round(rootC,3),
     data.table(coarseRoots = c(0.541, 1.569),
                fineRoots = c(0.347, 0.802))
   )
   expect_named(rootC, c("coarseRoots", "fineRoots"))
-  
+
   # Error with missspecified inputs
   expect_error(
     calcRootC(aboveGroundC = ABC[,.(Merch, Foliage, other = Other)], sw_hw = sw_hw)
   )
-  
+
   expect_error(
     calcRootC(aboveGroundC = ABC[,.(Merch, Foliage)], sw_hw = sw_hw)
   )
-  
+
   expect_error(
     calcRootC(aboveGroundC = ABC, sw_hw = c("sw", "hw"))
   )
-  
+
 })

--- a/tests/testthat/test-CBM-tools_calcRootC.R
+++ b/tests/testthat/test-CBM-tools_calcRootC.R
@@ -11,8 +11,8 @@ test_that("calcRootC", {
   # Works correctly
   expect_identical(
     round(rootC,3),
-    data.table(coarseRoots = c(0.541, 1.569),
-               fineRoots = c(0.347, 0.802))
+    data.table(coarseRoots = c(0.542, 1.570),
+               fineRoots = c(0.346, 0.802))
   )
   expect_named(rootC, c("coarseRoots", "fineRoots"))
 


### PR DESCRIPTION
Following the [manual of libcbm](https://cat-cfs.github.io/libcbm_py/cbm_exn.html), `sw_hw = 0` is softwood and `sw_hw = 1` is hardwood.

This has major consequences on the carbon proportions!