### PR TITLE
global variable reorganization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Implementation of several components of the Carbon Budget Model of 
     Canadian Forest Service (v3).
 URL:
     https://github.com/PredictiveEcology/CBMutils
-Version: 2.5.2.9001
+Version: 2.5.2.9002
 Authors@R: c(
     person("Céline",    "Boisvenue", email = "celine.boisvenue@nrcan-rncan.gc.ca", role = c("aut", "cre")),
     person("Alex M",    "Chubaty",   email = "achubaty@for-cast.ca",               role = c("aut"), comment = c(ORCID = "0000-0001-7146-8135")),

--- a/R/Boudewyn_cumPoolsCreateAGB.R
+++ b/R/Boudewyn_cumPoolsCreateAGB.R
@@ -1,6 +1,6 @@
 utils::globalVariables(
   c("..colToCheck",
-    "canfi_species", "juris_id", "ecozone", "age", "B", "speciesCode", "pixGroupCol",
+    "age", "B", "speciesCode", "pixGroupCol",
     "merch", "foliage", "other",
     "a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3", "biom_min", "biom_max",
     "p_sw_low", "p_sb_low", "p_br_low", "p_fl_low", "p_sw_high", "p_sb_high",

--- a/R/Boudewyn_cumPoolsSmooth.R
+++ b/R/Boudewyn_cumPoolsSmooth.R
@@ -1,5 +1,5 @@
 utils::globalVariables(c(
-  ".BY", ".N", ".SD", "gcids", "override"
+  "gcids", "override"
 ))
 
 #' Smooth the `cumPools` `data.table`

--- a/R/Boudewyn_growthCurves.R
+++ b/R/Boudewyn_growthCurves.R
@@ -1,6 +1,6 @@
 utils::globalVariables(c(
   "a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3",
-  "Age", "canfi_species", "eco", "ecozone", "genus", "gcids",
+  "Age", "eco", "gcids",
   "spatialUnitID", "SpatialUnitID", "species", "speciesName",
   "p_sw_low", "p_sw_high", "p_sb_low", "p_sb_high",
   "p_br_low", "p_br_high", "p_fl_low", "p_fl_high"

--- a/R/CBM-CBM_core_dbReadSummary.R
+++ b/R/CBM-CBM_core_dbReadSummary.R
@@ -1,4 +1,3 @@
-utils::globalVariables(c("cohortID", "pixelIndex", "row_idx"))
 
 #' simList: Read SpaDES CBM database summary
 #'
@@ -100,9 +99,6 @@ spadesCBMdbReadSummary <- function(spadesCBMdb, summary, by = "cohortID", year =
 
     dbTable <- .spadesCBMdbReadRaw(spadesCBMdb, year, "flux")
 
-    # R CMD check note bypass
-    for (colName in setdiff(names(dbTable), ls())) assign(colName, NULL)
-
     dbTable <- dbTable[, .(row_idx, NPP = rowSums(dbTable[, .(
       DeltaBiomass_AG, DeltaBiomass_BG,
       TurnoverMerchLitterInput, TurnoverFolLitterInput,
@@ -113,9 +109,6 @@ spadesCBMdbReadSummary <- function(spadesCBMdb, summary, by = "cohortID", year =
   if (summary == "poolTypes"){
 
     dbTable <- .spadesCBMdbReadRaw(spadesCBMdb, year, "pools")
-
-    # R CMD check note bypass
-    for (colName in setdiff(names(dbTable), ls())) assign(colName, NULL)
 
     dbTable <- dbTable[, .(
       Soil   = sum(AboveGroundVeryFastSoil, BelowGroundVeryFastSoil,
@@ -130,9 +123,6 @@ spadesCBMdbReadSummary <- function(spadesCBMdb, summary, by = "cohortID", year =
   if (summary == "totalCarbon"){
 
     dbTable <- .spadesCBMdbReadRaw(spadesCBMdb, year, "pools")
-
-    # R CMD check note bypass
-    for (colName in setdiff(names(dbTable), ls())) assign(colName, NULL)
 
     dbTable <- dbTable[, .(row_idx, totalCarbon = rowSums(dbTable[, .(
       Merch, Foliage, Other, CoarseRoots, FineRoots,

--- a/R/CBM-CBM_core_dbReadTable.R
+++ b/R/CBM-CBM_core_dbReadTable.R
@@ -1,4 +1,3 @@
-utils::globalVariables(c("cohortID", "pixelIndex", "row_idx"))
 
 #' simList: Read SpaDES CBM database table
 #'

--- a/R/CBM-DB_disturbances.R
+++ b/R/CBM-DB_disturbances.R
@@ -1,7 +1,6 @@
 
 utils::globalVariables(c(
-  "locale_id", "name", "spatial_unit_id",
-  "disturbance_type_id", "disturbance_matrix_id"
+  "source_pool", "sink_pool"
 ))
 
 #' CBM-CFS3 Spatial Unit Disturbances Match
@@ -240,10 +239,6 @@ seeDist <- function(EXN = TRUE, matrixIDs = NULL,
         as.data.table(dbReadTable(cbmDBcon, nm))
       })
     }
-
-    # CRAN requirement: predefine variables
-    id <- source_pool_id <- source_pool <- sink_pool_id <- sink_pool <- NULL
-    disturbance_matrix_id <- proportion <- code <- NULL
 
     cbmDBM[["pool_source"]] <- copy(cbmDBM[["pool"]])[, source_pool := code]
     cbmDBM[["pool_sink"]]   <- copy(cbmDBM[["pool"]])[, sink_pool   := code]

--- a/R/CBM-DB_species.R
+++ b/R/CBM-DB_species.R
@@ -1,4 +1,8 @@
 
+utils::globalVariables(c(
+  "Genus", "Latin_full", "EN_generic_full"
+))
+
 #' Species match
 #'
 #' Retrieve species metadata by matching species names or other identifiers with columns in \code{sppEquivalencies}.
@@ -37,8 +41,6 @@ sppMatch <- function(species, match = c("LandR", "Latin_full", "EN_generic_short
 
   # Create a "Genus" column from the latin name
   if ("Genus" %in% return & "Latin_full" %in% names(sppEquiv)){
-
-    Genus <- Latin_full <- EN_generic_full <- NULL
 
     sppEquiv[, Genus := toupper(
       sapply(strsplit(Latin_full, ""), function(x) ifelse(

--- a/R/CBM-plots_cTransfersAlluvial.R
+++ b/R/CBM-plots_cTransfersAlluvial.R
@@ -1,6 +1,5 @@
 utils::globalVariables(c(
-  "labelX", "labelY", "proportion", "sink_pool", "sink_pool_category", "source_pool", "stratum",
-  "disturbance_type_id", "disturbance_matrix_id", "spatial_unit_id", "sw_hw", "name", "description"
+  "labelX", "labelY", "sink_pool", "sink_pool_category", "source_pool", "stratum"
 ))
 
 #' `cTransfersAlluvial`

--- a/R/CBM-plots_mapNPP.R
+++ b/R/CBM-plots_mapNPP.R
@@ -1,8 +1,5 @@
 utils::globalVariables(c(
-  "DeltaBiomass_AG", "DeltaBiomass_BG",
-  "TurnoverMerchLitterInput", "TurnoverFolLitterInput",
-  "TurnoverOthLitterInput", "TurnoverCoarseLitterInput", "TurnoverFineLitterInput",
-  "NPP", "x", "y"
+  "NPP"
 ))
 
 #' `mapNPP`

--- a/R/CBM-plots_mapTotalCarbon.R
+++ b/R/CBM-plots_mapTotalCarbon.R
@@ -1,9 +1,5 @@
 utils::globalVariables(c(
-  "Merch", "Foliage", "Other", "CoarseRoots", "FineRoots",
-  "AboveGroundVeryFastSoil", "BelowGroundVeryFastSoil", "AboveGroundFastSoil",
-  "BelowGroundFastSoil", "MediumSoil", "AboveGroundSlowSoil", "BelowGroundSlowSoil",
-  "StemSnag", "BranchSnag",
-  "totalCarbon", "x", "y"
+  "totalCarbon"
 ))
 
 #' `mapTotalCarbon`

--- a/R/CBM-plots_plotEmissionsProducts.R
+++ b/R/CBM-plots_plotEmissionsProducts.R
@@ -1,5 +1,5 @@
 utils::globalVariables(c(
-  "emission", "emissionType", "Products", "year"
+  "emission", "emissionType"
 ))
 
 #' `plotEmissionsProducts`

--- a/R/CBM-plots_plotPoolProportions.R
+++ b/R/CBM-plots_plotPoolProportions.R
@@ -1,8 +1,6 @@
 utils::globalVariables(c(
-  "AboveGroundFastSoil", "AboveGroundSlowSoil", "AboveGroundVeryFastSoil",
-  "BelowGroundFastSoil", "BelowGroundSlowSoil", "BelowGroundVeryFastSoil",
-  "BranchSnag", "CoarseRoots", "FineRoots", "Foliage", "MediumSoil", "Merch", "Other", "StemSnag",
-  "AGlive", "BGlive", "carbon", "cohortGroupID", "N", "pool", "simYear", "snags", "soil", "weight"
+  "carbon", "N", "pool",
+  "AGlive", "BGlive", "Snags", "Soil"
 ))
 
 #' `plotPoolProportions`

--- a/R/CBM-tools_adjustCohortAges.R
+++ b/R/CBM-tools_adjustCohortAges.R
@@ -1,6 +1,6 @@
 
 utils::globalVariables(c(
-  "age", "ageCalc", "ageDist", "id", "prev", "year"
+  "ageCalc", "ageDist", "prev"
 ))
 
 #' Adjust cohort ages

--- a/R/CBMutils-package.R
+++ b/R/CBMutils-package.R
@@ -8,8 +8,60 @@
 #' @import methods
 "_PACKAGE"
 
+
 # data.table package common variables
+utils::globalVariables(c(".", ":=", ".BY", ".N", ".SD", ".GRP"))
+
+# Common spatial variables
+utils::globalVariables(c("x", "y", "z", "geometry", "area"))
+
+# Common keys
+utils::globalVariables(c("pixelIndex", "cohortID", "cohortGroupID", "year"))
+
+# Boudewyn table columns
 utils::globalVariables(c(
-  ".", ":="
+  "juris_id", "ecozone", "canfi_species", "genus", "species"
 ))
+
+# CBM defaults database columns
+utils::globalVariables(c(
+  "id", "locale_id", "name", "description",
+  "spatial_unit_id", "admin_boundary_id", "eco_boundary_id",
+  "disturbance_type_id", "disturbance_matrix_id",
+  "pool_id", "source_pool_id", "sink_pool_id", "code", "proportion"
+))
+
+# CBM-EXN cbm_vars columns
+utils::globalVariables(c(
+  "row_idx",
+
+  # cbm_vars$state
+  "area", "spatial_unit_id", "land_class_id", "age", "species", "sw_hw",
+  "time_since_last_disturbance", "time_since_land_use_change", "last_disturbance_type",
+  "mean_annual_temperature", "delay",
+
+  # cbm_vars$flux
+  "DisturbanceCO2Production", "DisturbanceCH4Production", "DisturbanceCOProduction",
+  "DisturbanceBioCO2Emission", "DisturbanceBioCH4Emission", "DisturbanceBioCOEmission",
+  "DecayDOMCO2Emission", "DisturbanceProduction", "DisturbanceDOMProduction",
+  "DeltaBiomass_AG", "DeltaBiomass_BG",
+  "TurnoverMerchLitterInput", "TurnoverFolLitterInput", "TurnoverOthLitterInput",
+  "TurnoverCoarseLitterInput", "TurnoverFineLitterInput",
+  "DecayVFastAGToAir", "DecayVFastBGToAir", "DecayFastAGToAir", "DecayFastBGToAir",
+  "DecayMediumToAir", "DecaySlowAGToAir", "DecaySlowBGToAir",
+  "DecayStemSnagToAir", "DecayBranchSnagToAir", "DisturbanceMerchToAir", "DisturbanceFolToAir",
+  "DisturbanceOthToAir", "DisturbanceCoarseToAir", "DisturbanceFineToAir",
+  "DisturbanceDOMCO2Emission", "DisturbanceDOMCH4Emission", "DisturbanceDOMCOEmission",
+  "DisturbanceMerchLitterInput", "DisturbanceFolLitterInput", "DisturbanceOthLitterInput",
+  "DisturbanceCoarseLitterInput", "DisturbanceFineLitterInput",
+  "DisturbanceVFastAGToAir", "DisturbanceVFastBGToAir", "DisturbanceFastAGToAir",
+  "DisturbanceFastBGToAir", "DisturbanceMediumToAir", "DisturbanceSlowAGToAir",
+  "DisturbanceSlowBGToAir", "DisturbanceStemSnagToAir", "DisturbanceBranchSnagToAir",
+
+  # cbm_vars$pools
+  "Input", "Merch", "Foliage", "Other", "CoarseRoots", "FineRoots",
+  "AboveGroundVeryFastSoil", "BelowGroundVeryFastSoil", "AboveGroundFastSoil", "BelowGroundFastSoil", "MediumSoil", "AboveGroundSlowSoil", "BelowGroundSlowSoil",
+  "StemSnag", "BranchSnag", "CO2", "CH4", "CO", "NO2", "Products"
+))
+
 

--- a/R/Misc-ageStepBackward.R
+++ b/R/Misc-ageStepBackward.R
@@ -1,4 +1,6 @@
-utils::globalVariables(c("x", "y", "z"))
+utils::globalVariables(c(
+  "rep", "inp", "ch"
+))
 
 #' Age Step Backwards
 #'
@@ -201,8 +203,6 @@ idw_replace <- function(
   }
 
   if (verbose) message("idw_replace: Reading inputs")
-
-  rep <- inp <- ch <- NULL
 
   cxyz[, rep := c %in% cells]
   cxyz[, inp := !rep & !z %in% ignore]

--- a/R/Misc-extractToRast.R
+++ b/R/Misc-extractToRast.R
@@ -168,7 +168,6 @@ extractToRast_vect <- function(input, templateRast, field = 1, crop = TRUE){
 
   # Reproject
   if (reproject){
-    geometry <- NULL # global variable binding
     sf::st_geometry(input) <- sf::st_transform(sf::st_geometry(input), sf::st_crs(templateRast))
   }
 


### PR DESCRIPTION
I've added a section to our package defining R file `R/CBMutils-package.R` that declares commonly used variables with `utils::globalVariables` between all of our functions. These were often declared in multiple files, or used in multiple files but only declared in some, etc. This will make it easy to use these variables anywhere.

This includes:
1. data.table special variables (e.g. `:=`)
2. Common spatial variables (e.g. `x`)
3. Common keys (e.g. `pixelIndex`)
3. Boudewyn table columns (e.g. `juris_id`)
4. CBM defaults database columns (e.g. `spatial_unit_id`)
5. CBM-EXN cbm_vars columns (e.g. `row_idx`)

We can add to this over time as we see fit.