### PR TITLE
cumPoolsSmooth uses `message` instead of `print` to print to console

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Implementation of several components of the Carbon Budget Model of 
     Canadian Forest Service (v3).
 URL:
     https://github.com/PredictiveEcology/CBMutils
-Version: 2.5.3.9000
+Version: 2.5.3.9001
 Authors@R: c(
     person("Céline",    "Boisvenue", email = "celine.boisvenue@nrcan-rncan.gc.ca", role = c("aut", "cre")),
     person("Alex M",    "Chubaty",   email = "achubaty@for-cast.ca",               role = c("aut"), comment = c(ORCID = "0000-0001-7146-8135")),

--- a/R/Boudewyn_cumPoolsSmooth.R
+++ b/R/Boudewyn_cumPoolsSmooth.R
@@ -33,17 +33,14 @@ cumPoolsSmooth <- function(cumPoolsRaw, colsToUse = c("totMerch", "fol", "other"
   cpr <- cumPoolsRaw # no copy -- just convenience
   cpr[, (colsToUse) := lapply(.SD, as.numeric), .SDcols = colsToUse]
 
-  outInd <- character()
+  i <- 0
+  nIDs <- length(unique(cpr[["gcids"]]))
 
-  outerInd <- 0
-  ## debugging tools
-  #cpr <- cpr[gcids %in% unique(cpr$gcids)[(198)]]
-  #message("REMOVE PREVIOUS LINE TO GET BACK ALL GCIDS")
-  lenUniqueID_ecozone <- length(unique(cpr[["gcids"]]))
   cpr[, (colsToUseNew) := {
-    outerInd <<- outerInd + 1
-    outInd <<- .BY
-    print(paste0(outerInd, " of ", lenUniqueID_ecozone, ": ", outInd))
+
+    i <<- i + 1
+    gcID <- .BY[[1]]
+    message(i, " of ", nIDs, ": ", as.character(gcID))
 
     N <- .N
     ind <- seq(N)
@@ -77,7 +74,6 @@ cumPoolsSmooth <- function(cumPoolsRaw, colsToUse = c("totMerch", "fol", "other"
 
       for (chopitoff in 1:4) {
         # Gets rid of wiggles and huge peak
-        #if (outInd > 17) browser()
         if (length(firstInflection) > 0) {
           SD[, override := ind > firstInflection & ind < firstMin]
           SD[override == TRUE, (c2u) := NA]
@@ -145,13 +141,11 @@ cumPoolsSmooth <- function(cumPoolsRaw, colsToUse = c("totMerch", "fol", "other"
           }
         }
       }
-      #browser()
+
       ind <- seq(N)
       if (is(nlsout, "try-error")) {
-      #   stop("This gcid ", .SD$gcids, " failed to converge while estimating Chapman Richards smoothing")
-        warning(c2u, " of gcid ", as.character(gcids), " (item ",outerInd,") failed to converge while estimating Chapman Richards smoothing; ",
+        warning(c2u, " of gcid ", as.character(gcID), " (item ", i, ") failed to converge while estimating Chapman Richards smoothing; ",
                 "Using original curve")
-        #if (outInd > 17) browser()
         newVals <- .SD[[c2u]]
       } else {
         fittedNew <- predict(nlsout, newdata = .SD)


### PR DESCRIPTION
This changes the console output for this function to be a message instead out printed output, allowing the SpaDES message prefix to be included with it, and it now includes the name of the gcID again. 

Currently the output looks like this:
```
1 of 40: 1
```

It now will look like:
```
Apr08 11:06:07 CBM_vl2bms:vol2biomass 1 of 40: SK_10_G_Betu_pap
```

I also removed a little bit of outdated debugging code where it mentions examining specific IDs.