### PR TITLE
sppEquivalencies read from URL; LandR removed from dependencies

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,8 @@
 ^\.github$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.positai$
+^\.claude$
 ^codecov\.yml$
 ^man-roxygen$
 ^README\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .Rhistory
 .RData
 .Ruserdata
+.positai
 inst/doc
 wip/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Implementation of several components of the Carbon Budget Model of 
     Canadian Forest Service (v3).
 URL:
     https://github.com/PredictiveEcology/CBMutils
-Version: 2.5.3.9002
+Version: 2.5.4.9000
 Authors@R: c(
     person("Céline",    "Boisvenue", email = "celine.boisvenue@nrcan-rncan.gc.ca", role = c("aut", "cre")),
     person("Alex M",    "Chubaty",   email = "achubaty@for-cast.ca",               role = c("aut"), comment = c(ORCID = "0000-0001-7146-8135")),
@@ -42,13 +42,11 @@ Suggests:
     exactextractr,
     FNN,
     qs2,
-    LandR,
     reproducible,
     SpaDES.core,
     rmarkdown,
     testthat
 Remotes:
-    PredictiveEcology/LandR@development,
     PredictiveEcology/reproducible@development,
     PredictiveEcology/SpaDES.core@development
 VignetteBuilder: knitr, rmarkdown

--- a/R/CBM-DB_species.R
+++ b/R/CBM-DB_species.R
@@ -28,13 +28,10 @@ sppMatch <- function(species, match = c("LandR", "Latin_full", "EN_generic_short
 
   # Read species equivalencies table
   if (is.null(sppEquivalencies)){
-    if (length(find.package("LandR", quiet = TRUE)) == 0) stop("LandR package required")
-    sppEquivalencies <- LandR::sppEquivalencies_CA
+    sppEquiv <- data.table::fread("https://github.com/PredictiveEcology/LandR/raw/refs/heads/development/data-raw/sppEquivalencies_CA.csv")
+  }else{
+    sppEquiv <- data.table::as.data.table(sppEquivalencies)
   }
-  sppEquiv <- tryCatch(
-    as.data.table(sppEquivalencies),
-    error = function(e) stop(
-      "sppEquivalencies could not be converted to data.table: ", e$message, call. = FALSE))
 
   # Return 0 rows
   if (length(species) == 0) return(sppEquiv[0,])

--- a/tests/testthat/test-Data-CBMsources.R
+++ b/tests/testthat/test-Data-CBMsources.R
@@ -5,17 +5,18 @@ test_that("CBMsourcePrepInputs", {
 
   inputPath <- file.path(testDirs$temp$outputs, "CBMsourcePrepInputs")
 
-  srcCBM <- CBMsourcePrepInputs("CanSIS-ecozone", inputPath = inputPath)
+  srcCBM <- CBMsourcePrepInputs("StatCan-admin", inputPath = inputPath)
   expect_is(srcCBM, "list")
-  expect_equal(srcCBM$attr, "ecozone")
   expect_is(srcCBM$source, "sf")
+  expect_equal(srcCBM$attr, "admin")
+  expect_true("admin" %in% names(srcCBM$source))
 
-  ## Backup test
-  # srcCBM <- CBMsourcePrepInputs("StatCan-admin", inputPath = inputPath)
+  ## Backup test: this source fails to download sometimes
+  # srcCBM <- CBMsourcePrepInputs("CanSIS-ecozone", inputPath = inputPath)
   # expect_is(srcCBM, "list")
-  # expect_equal(srcCBM$attr, "admin")
   # expect_is(srcCBM$source, "sf")
-  # expect_equal(names(srcCBM$source), c("admin", "geometry"))
+  # expect_equal(srcCBM$attr, "ecozone")
+  #  expect_true("ecozone" %in% names(srcCBM$source))
 })
 
 test_that("CBMsourceExtractToRast", {


### PR DESCRIPTION
Most of our GHA issues stem from issues installing the development version of LandR. Since our only use of the R package is to read the species equivalencies table, we have the option to simply to read this table directly from the source URL in the repo. Since this is the only place we connect to LandR (aside from, of course, LandR-CBM), this allows us to drop it as a dependency that needs to be installed as a package, saving us a lot of package installation set up trouble.