### PR TITLE
calcRootC parameter updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Implementation of several components of the Carbon Budget Model of 
     Canadian Forest Service (v3).
 URL:
     https://github.com/PredictiveEcology/CBMutils
-Version: 2.5.4.9000
+Version: 2.5.4.9001
 Authors@R: c(
     person("Céline",    "Boisvenue", email = "celine.boisvenue@nrcan-rncan.gc.ca", role = c("aut", "cre")),
     person("Alex M",    "Chubaty",   email = "achubaty@for-cast.ca",               role = c("aut"), comment = c(ORCID = "0000-0001-7146-8135")),

--- a/R/CBM-tools_calcRootC.R
+++ b/R/CBM-tools_calcRootC.R
@@ -15,6 +15,7 @@ utils::globalVariables(c(
 #' @param b_hw "b" value for hardwood root biomass
 #' @param a_frp "a" value for fine root proportion
 #' @param b_frp "b" value for fine root proportion
+#' @param c_frp "c" value for fine root proportion
 #' @param biomassToCarbonRate Conversion factor of biomass to carbon
 #'
 #' @references
@@ -29,7 +30,7 @@ utils::globalVariables(c(
 calcRootC <- function(aboveGroundC, sw_hw,
                       a_sw = 0.222, b_sw = 1,
                       a_hw = 1.576, b_hw = 0.615,
-                      a_frp = 0.072, b_frp = 0.354,
+                      a_frp = 0.072, b_frp = 0.354, c_frp = -0.060212,
                       biomassToCarbonRate = 0.5){
 
   aboveGroundColumns <- c("Merch", "Foliage", "Other")
@@ -55,7 +56,7 @@ calcRootC <- function(aboveGroundC, sw_hw,
                         a_hw * totAGB^b_hw)
 
   # Calculate the proportion of fine roots
-  fineRootProp <- a_frp + b_frp * exp(-0.060212 * rootTotBiom)
+  fineRootProp <- a_frp + b_frp * exp(c_frp * rootTotBiom)
 
 
   # Calculate the proportion of fine roots

--- a/R/CBM-tools_calcRootC.R
+++ b/R/CBM-tools_calcRootC.R
@@ -43,7 +43,7 @@ calcRootC <- function(aboveGroundC, sw_hw,
   totAGC <- rowSums(aboveGroundC[, ..aboveGroundColumns])
 
   # Convert Mg/ha of Carbon to Mg/ha of biomass
-  totAGB <- totAGC * 2
+  totAGB <- totAGC / biomassToCarbonRate
 
   # Calculate root total biomass
   if(!all(sw_hw %in% c(1,0))) {

--- a/man/calcRootC.Rd
+++ b/man/calcRootC.Rd
@@ -13,6 +13,7 @@ calcRootC(
   b_hw = 0.615,
   a_frp = 0.072,
   b_frp = 0.354,
+  c_frp = -0.060212,
   biomassToCarbonRate = 0.5
 )
 }
@@ -32,6 +33,8 @@ calcRootC(
 \item{a_frp}{"a" value for fine root proportion}
 
 \item{b_frp}{"b" value for fine root proportion}
+
+\item{c_frp}{"c" value for fine root proportion}
 
 \item{biomassToCarbonRate}{Conversion factor of biomass to carbon}
 }


### PR DESCRIPTION
1. [biomassToCarbonRate used in conversion of Mg/ha of Carbon to Mg/ha of biomass](https://github.com/PredictiveEcology/CBMutils/commit/7db3ede2a1ae684d7ee5b1d24b21d32e4b09b7ca)

In PR #79 I neglected to use the `biomassToCarbonRate` parameter in the initial conversion of carbon to biomass. It is used twice in this function.

3. [c_frp parameter added](https://github.com/PredictiveEcology/CBMutils/commit/a706d8096b77902914be4d8778dc4bbc9dbdf916)

frp c is a parameters in the CBM defaults database so I have added it as a function argument.