### PR TITLE
SpaDES.core removed from dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Implementation of several components of the Carbon Budget Model of 
     Canadian Forest Service (v3).
 URL:
     https://github.com/PredictiveEcology/CBMutils
-Version: 2.5.4.9000
+Version: 2.5.4.9001
 Authors@R: c(
     person("Céline",    "Boisvenue", email = "celine.boisvenue@nrcan-rncan.gc.ca", role = c("aut", "cre")),
     person("Alex M",    "Chubaty",   email = "achubaty@for-cast.ca",               role = c("aut"), comment = c(ORCID = "0000-0001-7146-8135")),
@@ -44,12 +44,10 @@ Suggests:
     FNN,
     qs2,
     reproducible,
-    SpaDES.core,
     rmarkdown,
     testthat
 Remotes:
     PredictiveEcology/reproducible@development,
-    PredictiveEcology/SpaDES.core@development,
     PredictiveEcology/CBM4r@main
 VignetteBuilder: knitr, rmarkdown
 Encoding: UTF-8

--- a/R/CBM-plots_mapNPP.R
+++ b/R/CBM-plots_mapNPP.R
@@ -83,16 +83,14 @@ cbm4MapNPP <- function(cbm4_results, years = NULL, yearStart = 1){
 #' @export
 simMapNPP <- function(simCBM, year = NULL, useCache = TRUE){
 
-  if (is.null(year)){
-    year <- SpaDES.core::convertTimeunit(SpaDES.core::times(simCBM)$current, "year")
-  }
+  if (is.null(year)) year <- simYears(simCBM)$current
 
   if (!is.null(simCBM$CBM4data)){
 
     cbm4MapNPP(
       simCBM$CBM4data,
       years     = year,
-      yearStart = SpaDES.core::start(simCBM)
+      yearStart = simYears(simCBM)$start
     )[[1]]
 
   }else{

--- a/R/CBM-plots_mapTotalCarbon.R
+++ b/R/CBM-plots_mapTotalCarbon.R
@@ -81,16 +81,14 @@ cbm4MapTotalCarbon <- function(cbm4_results, years = NULL, yearStart = 1){
 #' @export
 simMapTotalCarbon <- function(simCBM, year = NULL, useCache = TRUE){
 
-  if (is.null(year)){
-    year <- SpaDES.core::convertTimeunit(SpaDES.core::times(simCBM)$current, "year")
-  }
+  if (is.null(year)) year <- simYears(simCBM)$current
 
   if (!is.null(simCBM$CBM4data)){
 
     cbm4MapTotalCarbon(
       simCBM$CBM4data,
       years     = year,
-      yearStart = SpaDES.core::start(simCBM)
+      yearStart = simYears(simCBM)$start
     )[[1]]
 
   }else{

--- a/R/CBM-plots_plotEmissionsProducts.R
+++ b/R/CBM-plots_plotEmissionsProducts.R
@@ -105,12 +105,12 @@ simPlotEmissionsProducts <- function(simCBM, years = NULL, useCache = TRUE){
     cbm4PlotEmissionsProducts(
       simCBM$CBM4data,
       years     = years,
-      yearStart = SpaDES.core::start(simCBM)
+      yearStart = simYears(simCBM)$start
     )
 
   }else{
 
-    if (is.null(years)) years <- SpaDES.core::start(simCBM):SpaDES.core::end(simCBM)
+    if (is.null(years)) years <- with(simYears(simCBM), start:end)
 
     spadesCBMdbPlotEmissionsProducts(
       simCBM$spadesCBMdb,

--- a/R/CBM-plots_plotPoolProportions.R
+++ b/R/CBM-plots_plotPoolProportions.R
@@ -119,13 +119,13 @@ simPlotPoolProportions <- function(simCBM, years = NULL, useCache = TRUE){
 
     cbm4PlotPoolProportions(
       simCBM$CBM4data,
-      years      = years,
-      yearStart = SpaDES.core::start(simCBM)
+      years     = years,
+      yearStart = simYears(simCBM)$start
     )
 
   }else{
 
-    if (is.null(years)) years <- c(0, SpaDES.core::start(simCBM):SpaDES.core::end(simCBM))
+    if (is.null(years)) years <- c(0, with(simYears(simCBM), start:end))
 
     spadesCBMdbPlotPoolProportions(
       simCBM$spadesCBMdb,

--- a/R/spadesCBMdb_dbReadRaw.R
+++ b/R/spadesCBMdb_dbReadRaw.R
@@ -11,9 +11,7 @@
 #' @export
 simCBMdbReadRaw <- function(simCBM, year, table, ...){
 
-  if (missing(year)){
-    year <- SpaDES.core::convertTimeunit(SpaDES.core::times(simCBM)$current, "year")
-  }
+  if (missing(year)) year <- simYears(simCBM)$current
 
   spadesCBMdbReadRaw(simCBM$spadesCBMdb, year = year, table = table, ...)
 }

--- a/R/spadesCBMdb_dbReadSummary.R
+++ b/R/spadesCBMdb_dbReadSummary.R
@@ -16,13 +16,9 @@
 simCBMdbReadSummary <- function(simCBM, summary, by = "cohortID", units = "t/ha",
                                 year = NULL, years = NULL, useCache = TRUE){
 
-  if (is.null(year) & by != "year"){
-    year <- SpaDES.core::convertTimeunit(SpaDES.core::times(simCBM)$current, "year")
-  }
-  if (is.null(years) & by == "year"){
-    simTimes <- lapply(SpaDES.core::times(simCBM)[c("start", "end")], SpaDES.core::convertTimeunit, "year")
-    years <- simTimes$start:simTimes$end
-  }
+  if (is.null(year)  & by != "year") year  <- simYears(simCBM)$current
+  if (is.null(years) & by == "year") years <- with(simYears(simCBM), start:end)
+
   spadesCBMdbReadSummary(
     simCBM$spadesCBMdb,
     summary  = summary,

--- a/R/spadesCBMdb_dbReadTable.R
+++ b/R/spadesCBMdb_dbReadTable.R
@@ -11,9 +11,7 @@
 #' @export
 simCBMdbReadTable <- function(simCBM, year, table, useCache = TRUE){
 
-  if (missing(year)){
-    year <- SpaDES.core::convertTimeunit(SpaDES.core::times(simCBM)$current, "year")
-  }
+  if (missing(year)) year <- simYears(simCBM)$current
 
   spadesCBMdbReadTable(simCBM$spadesCBMdb, year = year, table = table, useCache = useCache)
 }

--- a/R/spadesCBMdb_dbWrite.R
+++ b/R/spadesCBMdb_dbWrite.R
@@ -10,9 +10,7 @@
 #' @export
 simCBMdbWrite <- function(simCBM, year, parameters = TRUE, state = TRUE, flux = TRUE, pools = TRUE){
 
-  if (missing(year)){
-    year <- SpaDES.core::convertTimeunit(SpaDES.core::times(simCBM)$current, "year")
-  }
+  if (missing(year)) year <- simYears(simCBM)$current
 
   spadesCBMdbWrite(
     simCBM$spadesCBMdb,

--- a/R/utils-simList.R
+++ b/R/utils-simList.R
@@ -1,0 +1,21 @@
+
+# Get simList times in years without using SpaDES.core functions
+simYears <- function(sim){
+
+  simTimes <- sim@simtimes[c("current", "start", "end")]
+  simTimes <- lapply(simTimes, function(st){
+    if (attr(st, "unit") == "second"){
+      st <- st / (60 * 60 * 24 * 365.25)
+      attr(st, "unit") <- "year"
+    }
+    return(st)
+  })
+
+  if (!all(sapply(simTimes, attr, "unit") == "year") |
+      any(simTimes$start > c(sim$simTimes$current, sim$simTimes$end)) |
+      any(simTimes$end   < c(sim$simTimes$current, sim$simTimes$start))) stop(
+        "Converting sim@simtimes to unit 'year' failed")
+
+  return(simTimes)
+}
+

--- a/tests/testthat/devel-runTests.R
+++ b/tests/testthat/devel-runTests.R
@@ -7,8 +7,10 @@ testthat::test_local(filter = "Boudewyn")
 testthat::test_local(filter = "CBM-DB")
 testthat::test_local(filter = "CBM-plots")
 testthat::test_local(filter = "CBM-tools")
+testthat::test_local(filter = "Data")
 testthat::test_local(filter = "Misc")
 testthat::test_local(filter = "Python")
+testthat::test_local(filter = "spadesCBMdb")
 
 # Run individual tests
 testthat::test_local(filter = "Boudewyn_cumPoolsCreate")

--- a/tests/testthat/test-spadesCBMdb_plots.R
+++ b/tests/testthat/test-spadesCBMdb_plots.R
@@ -13,8 +13,7 @@ masterRaster <- terra::rast(
   ncols = 1950, xmax = 1950 * 30,
   nrows = 1900, ymax = 1900 * 30)
 
-simCBM <- SpaDES.core::simInit(
-  times        = list(start = 1985, end = 2011),
+simCBM <- list(
   spadesCBMdb  = spadesCBMdb,
   masterRaster = masterRaster
 )

--- a/tests/testthat/test-spadesCBMdb_read-write.R
+++ b/tests/testthat/test-spadesCBMdb_read-write.R
@@ -31,12 +31,13 @@ test_that("simCBMdbWrite", {
 
   spadesCBMdbTemp <- file.path(testDirs$temp$outputs, "spadesCBMdb", "simCBMdbWrite")
 
-  simCBM <- SpaDES.core::simInit(times = list(start = 1985, end = 2011))
-  simCBM$spadesCBMdb <- spadesCBMdbTemp
-  simCBM$cbm_vars <- list(key = "test", flux = "test", pools = "test")
+  simCBM <- list(
+    spadesCBMdb = spadesCBMdbTemp,
+    cbm_vars    = list(key = "test", flux = "test", pools = "test")
+  )
 
   simCBMdbWrite(
-    simCBM,
+    simCBM, year = 1985,
     parameters = FALSE,
     state      = FALSE,
     flux       = TRUE,
@@ -82,8 +83,9 @@ test_that("spadesCBMdbReadRaw", {
 
 test_that("simCBMdbReadRaw", {
 
-  simCBM <- SpaDES.core::simInit(times = list(start = 1985, end = 2011))
-  simCBM$spadesCBMdb <- spadesCBMdb
+  simCBM <- list(
+    spadesCBMdb = spadesCBMdb
+  )
 
   key2011 <- simCBMdbReadRaw(
     simCBM = simCBM,
@@ -98,6 +100,7 @@ test_that("simCBMdbReadRaw", {
 
   pools1985 <- simCBMdbReadRaw(
     simCBM = simCBM,
+    year   = 1985,
     table  = "pools"
   )
   expect_is(pools1985, "data.table")
@@ -150,11 +153,13 @@ test_that("spadesCBMdbReadTable", {
 
 test_that("simCBMdbReadTable", {
 
-  simCBM <- SpaDES.core::simInit(times = list(start = 1985, end = 2011))
-  simCBM$spadesCBMdb <- spadesCBMdb
+  simCBM <- list(
+    spadesCBMdb = spadesCBMdb
+  )
 
   pools1985 <- simCBMdbReadTable(
     simCBM   = simCBM,
+    year     = 1985,
     table    = "pools",
     useCache = FALSE
   )
@@ -168,6 +173,7 @@ test_that("simCBMdbReadTable", {
   expect_equal(
     simCBMdbReadTable(
       simCBM   = simCBM,
+      year     = 1985,
       table    = "pools",
       useCache = TRUE
     ),
@@ -252,8 +258,9 @@ test_that("spadesCBMdbReadSummary", {
 
 test_that("simCBMdbReadSummary", {
 
-  simCBM <- SpaDES.core::simInit(times = list(start = 1985, end = 2011))
-  simCBM$spadesCBMdb <- spadesCBMdb
+  simCBM <- list(
+    spadesCBMdb = spadesCBMdb
+  )
 
   pools1985 <- simCBMdbReadSummary(
     simCBM   = simCBM,


### PR DESCRIPTION
SpaDES.core@development is a suggested dependency but since suggested packages are installed for our GHA checks, having it in our package list risks encountering install issues related to the SpaDES.core@development branch.

Since SpaDES.core is only used to get times from the `simList` I have added a utility function called `simYears` that can read the times directly from the `simList` object without using SpaDES.core functions such as `start(sim)`.